### PR TITLE
Exclude vendor folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ url: ""
 markdown: kramdown # the preferred markdown processor
 
 # things that should be excluded from a jekyll build
-exclude: [README.md, Rakefile, .gitignore, Gemfile, Gemfile.lock]
+exclude: [README.md, Rakefile, .gitignore, Gemfile, Gemfile.lock, vendor]
 
 # post permalink URL structure
 permalink: /:title


### PR DESCRIPTION
As per https://jekyllrb.com/docs/continuous-integration/#configuring-your-travis-builds 
CI builds will put gems in vendor folder which confuses jekyll.
